### PR TITLE
Massive core refactoring + Tracking state indicator

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,11 @@
 {
 	"id": "timethings",
 	"name": "Time Things",
-	"version": "1.3.0",
+	"version": "2.0.0",
 	"minAppVersion": "0.15.0",
-	"description": "Show clock in the corner. Track total editing time of a note and the last time it was modified.",
-	"author": "Nick Winters",
-	"authorUrl": "https://github.com/plasmabit",
-	"fundingUrl": "https://www.patreon.com/nickwinters",
+	"description": "Track total editing time of a note and the last time it was modified. Show clock and/or editing indicator in the corner",
+	"author": "Nick Winters, Rupel Rupelsson",
+	"authorUrl": "https://github.com/plasmabit, https://github.com/rupel190",
+	"fundingUrl": "https://www.patreon.com/nickwinters, https://ko-fi.com/rupel190",
 	"isDesktopOnly": true
 }

--- a/src/CAMS.ts
+++ b/src/CAMS.ts
@@ -91,9 +91,11 @@ export function setValue(editor: Editor, fieldPath: string, fieldValue: string,)
 	// The thing with this function is that it uses the format from settings to check against. I can make it as an argument that can be passed, or better yet, eradicate the check from the function to make it more atomic and place it somewhere else in the main code.
 	const fieldLine = getLine(editor, fieldPath);
 	if (fieldLine === undefined) {
+        console.log("!!!fieldline undefined"); // TODO: delete
 		return;
 	}
 	const initialLine = editor.getLine(fieldLine).split(":", 1);
 	const newLine = initialLine[0] + ": " + fieldValue;
+    console.log('!!!fieldline/newline', fieldLine, newLine);
 	editor.setLine(fieldLine, newLine);
 }

--- a/src/gates.utils.ts
+++ b/src/gates.utils.ts
@@ -11,7 +11,7 @@ export interface FilterList {
 
 export function isFileMatchFilter(file: TFile, filter: FilterList,): boolean {
     // Check if file matches paths
-    if (isStringInList(file.parent.path, filter.folders)) {
+    if (file.parent && isStringInList(file.parent.path, filter.folders)) {
         return true;
     }
     // Check if file matches tags
@@ -27,7 +27,7 @@ export function isStringInList(path: string, list: string[]): boolean {
 export async function isTagPresentInFile(file: TFile, tag: string,) {
     await this.app.fileManager.processFrontMatter(
         file as TFile,
-        (frontmatter) => {
+        (frontmatter: any) => {
             const updateKeyValue = BOMS.getValue(frontmatter, "tags");
             if (updateKeyValue.includes(tag))
             {

--- a/src/main.ts
+++ b/src/main.ts
@@ -226,16 +226,13 @@ export default class TimeThings extends Plugin {
 	}
 
 	
+	// not just on the setting as BOMS apparently requires a min of 10s 
+	// -> TODO: Limit Timeout if BOMS is active! Provide slider + numberbox > 10 for BOMS, >1 for cams)
+	
+	// Run every x seconds starting from typing begin and update periodically
 	startTime: number | null;
-	exactTimeDiff: number | null;
-	cumulatedTimeDiff: number = 0;
-	// the frontmatter update should happen periodically, but the timeout depends on BOMS/CAMS,
-	// not just on the setting as BOMS apparently requires a min of 10s -> TODO: Limit Timeout if BOMS is active!
 	updateEditedValue = debounce((useCustomSolution: boolean, activeView: MarkdownView) => {
-			// Run every x seconds starting from typing begin and update periodically
 			if(this.startTime) {
-				this.cumulatedTimeDiff += this.timeout;
-				console.log('Cumulated timediff: ', this.cumulatedTimeDiff);
 				this.updateMetadata(useCustomSolution, activeView);
 			}
 		}, this.timeout, false);
@@ -257,7 +254,6 @@ export default class TimeThings extends Plugin {
 		this.updateEditedValue(useCustomSolution, activeView);
 		this.resetEditing();
 	}
-
 
 	updateMetadata (useCustomSolution: boolean, activeView: MarkdownView) {
 		let environment;
@@ -301,7 +297,6 @@ export default class TimeThings extends Plugin {
 		// Check if the file has a property that puts it into a blacklist
 		// Check if the file itself is in the blacklist
 		
-        
 		console.log('--- User activity! ---');
 		
         if (updateStatusBar) {
@@ -389,7 +384,7 @@ export default class TimeThings extends Plugin {
 		}
 
 		// Increment & set
-		const incremented = moment.duration(value).add(this.timeout, 'milliseconds').format(userDateFormat, { trim: false }); // Stick to given format
+		const incremented = moment.duration(value).add(this.timeout, 'milliseconds').format(userDateFormat, { trim: false }); // Always stick to given format
 		this.isDebugBuild && console.log(`Increment CAMS from ${value} to ${incremented}`);
 		CAMS.setValue(
 			editor,

--- a/src/main.ts
+++ b/src/main.ts
@@ -316,6 +316,7 @@ export default class TimeThings extends Plugin {
 
 	// BOMS (Default)
     async updateModifiedPropertyFrontmatter(file: TFile) {
+		// TODO update
 		await this.app.fileManager.processFrontMatter(
 			file as TFile,
 			(frontmatter) => {
@@ -352,45 +353,54 @@ export default class TimeThings extends Plugin {
 	
 	/* Date updating is delicate: Moment.js validity check might check an updated setting
 		against a pre-existing date and would return false. So it would never act on old documents.
-		Instead: Check existing date for general validity. Add diff. Check if the new format is valid and display as such.
+		Instead: Check existing duration for general validity. Add diff. Check if the new format is valid and display as such.
 	*/ 
 	// CAMS
 	async updateDurationPropertyEditor(editor: Editor) {
 
+		//TODO update
+
+		
+		// Fetch edit duration
+		const fieldLine: number | undefined = CAMS.getLine(editor, this.settings.editDurationKeyName); 
+		const userDateFormat = this.settings.editDurationKeyFormat;
+		let newValue : any;
+
+		console.log("---------------------------")
+		console.log('frontmatter', CAMS.getLine(editor, this.settings.editDurationKeyName));
+		console.log('frontmatter2', CAMS.getLine(editor,  this.settings.editDurationKeyName))
 		
 
-		// if(!moment(value).isValid()) {
-		// 	this.isDebugBuild && console.log("Wrong format of updated_at property!");
-		// 	return;
-		// }
-
-
-
-		// Fetch value
-		let fieldLine: number | undefined = CAMS.getLine(editor, this.settings.editDurationKeyName); 
+		console.log('key name: ', this.settings.editDurationKeyName);
+		console.log('cams prop', CAMS.getLine(editor, this.settings.editDurationKeyName));
+		console.log('editor fieldline', (CAMS.getLine(editor, this.settings.editDurationKeyName)));
+		
 		if(fieldLine === undefined) {
-			console.log("Undefined value for duration property");
-			fieldLine = 0;
+			console.log(`Undefined value for ${this.settings.editDurationKeyName}`);
+			newValue = moment.duration(0, "minutes").format(userDateFormat, { trim: false })
+			console.log('set value here');
+			
+			CAMS.setValue(editor, "welltest", newValue);
+
+		} else {
+			newValue = editor.getLine(fieldLine).split(/:(.*)/s)[1].trim();
+			const test = moment(newValue, userDateFormat, true).isValid()
+			console.log("test vlaid? ", test)
 		}
-		// Parse & check validity TODO: Doesn't make sense because the format might change and we're checking enw format against existing frontmatter format
-		const value = editor.getLine(fieldLine).split(/:(.*)/s)[1].trim();
-		const userDateFormat = this.settings.editDurationKeyFormat;
-		if(moment(value, userDateFormat, true).isValid() === false) {
-			this.isDebugBuild && console.log("Wrong format or invalid value with edit_duration property");
-			return;
-		}
+
+		this.isDebugBuild && console.log(`Current edit duration ${newValue} and current/new formatter ${userDateFormat}`);
+
 		// Increment & set
-		const incremented = moment.duration(value).add(this.timeout, 'milliseconds').format(userDateFormat, { trim: false }); // Always stick to given format
-		this.isDebugBuild && console.log(`Increment CAMS from ${value} to ${incremented}`);
-		CAMS.setValue(
-			editor,
-			this.settings.editDurationKeyName,
-			incremented.toString(),
-		);
+		const incremented = moment.duration(newValue).add(this.timeout, 'milliseconds').format(userDateFormat, { trim: false }); // Always stick to given format
+		this.isDebugBuild && console.log(`Increment CAMS from ${newValue} to ${incremented}`);
+		CAMS.setValue(editor, this.settings.editDurationKeyName, incremented.toString());
 	}
 
 	// BOMS (Default)
     async updateDurationPropertyFrontmatter(file: TFile) {
+
+		// TODO update
+
         // Slow update
         await this.app.fileManager.processFrontMatter(
             file as TFile,
@@ -495,9 +505,6 @@ export default class TimeThings extends Plugin {
 		this.resetIcon = debounce(() => {
 			// Inactive typing
 			this.editIndicatorBar.setText(this.settings.editIndicatorInactive);
-			console.log('this is inactive: ', this.settings.editIndicatorInactive);
-			console.log('this is active: ', this.settings.editIndicatorActive);
-
 			this.activityIconActive = false;
 			this.isDebugBuild && console.log('Deactivate typing icon, active: ', this.activityIconActive);
 		}, this.timeout, true);

--- a/src/main.ts
+++ b/src/main.ts
@@ -308,6 +308,9 @@ export default class TimeThings extends Plugin {
 
 	// CAMS
     updateModifiedPropertyEditor(editor: Editor) {
+		this.isDebugBuild && console.log('CAMS: Update modified property!');
+		// With the old solution updating frontmatter keys only worked on BOMS!
+		// todo: allow key changes
 		const userDateFormat = this.settings.modifiedKeyFormat; // Target format. Existing format unknown and irrelevant.
 		const userModifiedKeyName = this.settings.modifiedKeyName;
 		const dateFormatted = moment().format(userDateFormat);
@@ -316,34 +319,13 @@ export default class TimeThings extends Plugin {
 
 	// BOMS (Default)
     async updateModifiedPropertyFrontmatter(file: TFile) {
-		// TODO update
+		this.isDebugBuild && console.log('--- BOMS: Update modified property! ---');
 		await this.app.fileManager.processFrontMatter(
 			file as TFile,
 			(frontmatter) => {
-				const dateNow = moment();
-				const dateFormatted = dateNow.format(
-					this.settings.modifiedKeyFormat,
-				);
-
-				const updateKeyValue = moment(
-					BOMS.getValue(frontmatter, this.settings.modifiedKeyName),
-					this.settings.modifiedKeyFormat,
-				);
-
-				if (
-					updateKeyValue.add(
-						this.timeout,
-						"minutes",
-					) > dateNow
-				) {
-					return;
-				}
-
-				BOMS.setValue(
-					frontmatter,
-					this.settings.modifiedKeyName,
-					dateFormatted,
-				);
+				const dateFormatted = moment().format(this.settings.modifiedKeyFormat);
+				// BOMS creates key if it doesn't exist
+				BOMS.setValue(frontmatter,this.settings.modifiedKeyName, dateFormatted);
 			},
 		);
 	}
@@ -357,6 +339,8 @@ export default class TimeThings extends Plugin {
 	*/ 
 	// CAMS
 	async updateDurationPropertyEditor(editor: Editor) {
+		this.isDebugBuild && console.log('CAMS: Update duration property!');
+		// With the old solution updating frontmatter keys only worked on BOMS!
 
 		//TODO update
 
@@ -398,6 +382,7 @@ export default class TimeThings extends Plugin {
 
 	// BOMS (Default)
     async updateDurationPropertyFrontmatter(file: TFile) {
+		this.isDebugBuild && console.log('--- BOMS: Update duration property! ---');
 
 		// TODO update
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,6 +28,7 @@ export default class TimeThings extends Plugin {
 	settings: TimeThingsSettings;
 	isDebugBuild: boolean;
 	clockBar: HTMLElement; // # Required
+	editingBar: HTMLElement;
 	debugBar: HTMLElement;
 	editDurationBar: HTMLElement;
 	isEditing = false;
@@ -171,6 +172,7 @@ export default class TimeThings extends Plugin {
 				if (
 					this.settings.useCustomFrontmatterHandlingSolution === false
 				) {
+					console.log('this2 ');
 					this.onUserActivity(false, activeView);
 				}
 			}),
@@ -208,7 +210,7 @@ export default class TimeThings extends Plugin {
 	iconActive : boolean = false; // In a perfect world this matches the editing timer, but it's way simpler to decouple these variables
 	// Inactive typing
 	resetIcon = debounce(() => {
-		this.clockBar.setText(`✋🔴`); //TODO: settings.ts
+		this.editingBar.setText(`✋🔴`); //TODO: settings.ts
 		this.iconActive = false;
 		this.isDebugBuild && console.log('Deactivate typing icon, active: ', this.iconActive);
 	}, this.timeout, true);
@@ -216,7 +218,7 @@ export default class TimeThings extends Plugin {
 	// Active typing icon
 	updateIcon() {
 		if(!this.iconActive) {
-			this.clockBar.setText(`✏🔵`);
+			this.editingBar.setText(`✏🔵`);
 			this.iconActive = true;
 			this.isDebugBuild && console.log('Activate typing icon, active: ', this.iconActive);
 		}
@@ -433,21 +435,14 @@ export default class TimeThings extends Plugin {
 		const dateChosen = this.settings.isUTC ? dateUTC : dateNow;
 		const dateFormatted = dateChosen.format(this.settings.clockFormat);
 		const emoji = timeUtils.momentToClockEmoji(dateChosen);
-
-		// TODO: Remove override
-		// this.settings.showEmojiStatusBar
-		// 	? this.clockBar.setText(emoji + " " + dateFormatted)
-		// 	: this.clockBar.setText(dateFormatted);
-
 	}
 
-    // Gets called on OnLoad
+    // Called on OnLoad, adds status bar
     setUpStatusBarItems() {
 		if (this.settings.enableClock) {
 			// Add clock icon
-			// Adds a status bar
 			this.clockBar = this.addStatusBarItem();
-			this.clockBar.setText(":)");
+			this.clockBar.setText(timeUtils.momentToClockEmoji(moment()));
 
 			// Change status bar text every second
 			this.updateClockBar();
@@ -457,6 +452,10 @@ export default class TimeThings extends Plugin {
 					+this.settings.updateIntervalMilliseconds,
 				),
 			);
+		}
+		if (this.settings.enableEditStatus) {
+			this.editingBar = this.addStatusBarItem();
+			this.editingBar.setText(this.settings.editIndicatorActive);
 		}
 
 	}

--- a/src/main.ts
+++ b/src/main.ts
@@ -316,7 +316,7 @@ export default class TimeThings extends Plugin {
 			console.log("!!!Attempt to init frontmatter");
 			BOMS.setValue(editor, userModifiedKeyName, dateFormatted);
 		}
-		CAMS.setValue(editor, userModifiedKeyName, dateFormatted);
+		CAMS.setLine(editor, userModifiedKeyName, dateFormatted);
 	} 
 
 	// BOMS (Default)
@@ -360,7 +360,7 @@ export default class TimeThings extends Plugin {
 		// Increment & set
 		const incremented = moment.duration(newValue).add(this.timeout, 'milliseconds').format(userDateFormat, { trim: false }); // Always stick to given format
 		this.isDebugBuild && console.log(`Increment CAMS edit duration from ${newValue} to ${incremented}`);
-		CAMS.setValue(editor, this.settings.editDurationKeyName, incremented.toString());
+		CAMS.setLine(editor, this.settings.editDurationKeyName, incremented.toString());
 	}
 
 	// BOMS (Default)

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,7 +30,6 @@ export default class TimeThings extends Plugin {
 	clockBar: HTMLElement; // # Required
 	debugBar: HTMLElement;
 	editDurationBar: HTMLElement;
-	allowEditDurationUpdate: boolean;
 	isEditing = false;
 
 	async onload() {
@@ -61,7 +60,6 @@ export default class TimeThings extends Plugin {
 
 		// Variables initialization
 		this.isDebugBuild = true; // for debugging purposes TODO: WELL IS IT OR IS IT NOT APPARENTLY ITS NOT IF THIS TEXT IS HERE!
-		this.allowEditDurationUpdate = true; // for cooldown
 
         // Set up Status Bar items
 		this.setUpStatusBarItems();
@@ -408,6 +406,8 @@ export default class TimeThings extends Plugin {
 					this.isDebugBuild && console.log("Wrong format for edit_duration property");
 					return;
 				}
+
+				// TODO: Do this right in the settings. Maybe the date could also be validated directly in the settings?
 				if(this.timeout < 10000) {
 					console.log('Invalid timeout for BOMS, reset to 10 seconds.');
 					this.timeout = 10000;

--- a/src/main.ts
+++ b/src/main.ts
@@ -250,10 +250,7 @@ export default class TimeThings extends Plugin {
 		const editDiff = this.validEditDuration()
 		const modificationThreshold = this.settings.modifiedThreshold/1000;
 
-		if (
-			useCustomSolution &&
-			environment instanceof Editor
-		) {
+		if (useCustomSolution && environment instanceof Editor) {
 			// CAMS: Custom Asset Management System
 			console.log("Calling CAMS handler");
 			if(editDiff !== null && editDiff >= modificationThreshold) {
@@ -263,10 +260,7 @@ export default class TimeThings extends Plugin {
 			if (this.settings.enableEditDurationKey) {
 				this.updateDurationPropertyCAMS(environment);
 			}
-		} else if (
-			!useCustomSolution &&
-			environment instanceof TFile
-		) {			
+		} else if (!useCustomSolution && environment instanceof TFile) {			
 			// BOMS: Build-in Object Management System
 			console.log("Calling BOMS handler");
 			if(editDiff !== null && editDiff >= modificationThreshold) {
@@ -315,6 +309,13 @@ export default class TimeThings extends Plugin {
 		const userDateFormat = this.settings.modifiedKeyFormat; // Target format. Existing format unknown and irrelevant.
 		const userModifiedKeyName = this.settings.modifiedKeyName;
 		const dateFormatted = moment().format(userDateFormat);
+
+		const fetched = CAMS.getLine(editor, this.settings.modifiedKeyName)
+		if(fetched === undefined) {
+			// TODO: Initialize somehow, cause it's not crfeated by using CAMS!
+			console.log("!!!Attempt to init frontmatter");
+			BOMS.setValue(editor, userModifiedKeyName, dateFormatted);
+		}
 		CAMS.setValue(editor, userModifiedKeyName, dateFormatted);
 	} 
 
@@ -326,7 +327,7 @@ export default class TimeThings extends Plugin {
 			(frontmatter) => {
 				const dateFormatted = moment().format(this.settings.modifiedKeyFormat);
 				// BOMS creates key if it doesn't exist
-				BOMS.setValue(frontmatter,this.settings.modifiedKeyName, dateFormatted);
+				BOMS.setValue(frontmatter, this.settings.modifiedKeyName, dateFormatted);
 			},
 		);
 	}
@@ -368,7 +369,6 @@ export default class TimeThings extends Plugin {
 		Instead: Check existing duration for general validity. Increment. Display. (Format is validated in settings)
 	*/ 
     async updateDurationPropertyBOMS(file: TFile) {
-		
 		this.isDebugBuild && console.log('*** BOMS: Update duration property! ***');
         // Slow update
         await this.app.fileManager.processFrontMatter(

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -51,8 +51,8 @@ export const DEFAULT_SETTINGS: TimeThingsSettings = {
 	enableEditDurationKey: true,
 	editTimeoutMilliseconds: 3000,
 	enableEditStatus: true,
-	editIndicatorActive: "✋🔴",
-	editIndicatorInactive: "✏🔵",
+	editIndicatorActive: "✏🔵",
+	editIndicatorInactive: "✋🔴",
 
 	updateIntervalFrontmatterMinutes: 1,
 
@@ -243,10 +243,10 @@ export class TimeThingsSettingsTab extends PluginSettingTab {
 
 		if (this.plugin.settings.enableEditStatus === true) {
 			new Setting(containerEl.createDiv({cls: "statusBarTypingIndicator"}))
-				.setName("Icon for tracking active/inactive")
+				.setName("Icon for tracking inactive/active")
 				.addText((text) =>
 					text
-						.setPlaceholder(this.plugin.settings.editIndicatorActive)
+						.setPlaceholder("Inactive")
 						.setValue(this.plugin.settings.editIndicatorActive)
 						.onChange(async (value) => {
 							this.plugin.settings.editIndicatorActive = value;
@@ -255,7 +255,7 @@ export class TimeThingsSettingsTab extends PluginSettingTab {
 				)
 				.addText((text) =>
 					text
-						.setPlaceholder("Your moj")
+						.setPlaceholder("Active")
 						.setValue(this.plugin.settings.editIndicatorInactive)
 						.onChange(async (value) => {
 							this.plugin.settings.editIndicatorInactive = value;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -16,7 +16,7 @@ export interface TimeThingsSettings {
 	enableModifiedKey: boolean;
 	modifiedKeyName: string;
 	modifiedKeyFormat: string;
-	modifiedThreshold: number; // todo: add settings field
+	modifiedThreshold: number;
 	
     //DURATION KEY
 	enableEditDurationKey: boolean;
@@ -64,7 +64,7 @@ export class TimeThingsSettingsTab extends PluginSettingTab {
 		const { containerEl } = this;
 		containerEl.empty();
 
-		// #region prerequisites
+		// #region Prerequisites
 		const createLink = () => {
 			const linkEl = document.createDocumentFragment();
 
@@ -80,7 +80,7 @@ export class TimeThingsSettingsTab extends PluginSettingTab {
 
 
 
-		// #region custom frontmatter solution
+		// #region General
 		let mySlider : SliderComponent;
 		let myText: TextComponent;
 		const minTimeoutBoms = 10; // Not sure
@@ -108,7 +108,7 @@ export class TimeThingsSettingsTab extends PluginSettingTab {
 							if(this.plugin.settings.typingTimeoutMilliseconds < minTimeoutBoms * 1000) {
 								this.plugin.settings.typingTimeoutMilliseconds = minTimeoutBoms * 1000;
 								myText.setValue(minTimeoutBoms.toString());
-								console.log("Bump BOMS timeout", this.plugin.settings.typingTimeoutMilliseconds);
+								// console.log("Bump BOMS timeout", this.plugin.settings.typingTimeoutMilliseconds);
 							}
 						}
 						await this.plugin.saveSettings();
@@ -149,12 +149,10 @@ export class TimeThingsSettingsTab extends PluginSettingTab {
 					await this.plugin.saveSettings();
 				})
 		});
-			
-
 		// #endregion
 
 
-		// #region status bar
+		// #region Status bar
 		containerEl.createEl("h1", { text: "Status bar" });
 		containerEl.createEl("p", { text: "Display symbols in the status bar" });
         containerEl.createEl("h2", { text: "🕰️ Clock" });
@@ -232,7 +230,7 @@ export class TimeThingsSettingsTab extends PluginSettingTab {
 						.setPlaceholder("Active")
 						.setValue(this.plugin.settings.editIndicatorActive)
 						.onChange(async (value) => {
-							console.log('update active tracking icon: ', value)
+							// console.log('update active tracking icon: ', value)
 							this.plugin.settings.editIndicatorActive = value;
 							await this.plugin.saveSettings();
 						}),
@@ -242,8 +240,7 @@ export class TimeThingsSettingsTab extends PluginSettingTab {
 						.setPlaceholder("Inactive")
 						.setValue(this.plugin.settings.editIndicatorInactive)
 						.onChange(async (value) => {
-							console.log('update inactive tracking icon: ', value)
-
+							// console.log('update inactive tracking icon: ', value)
 							this.plugin.settings.editIndicatorInactive = value;
 							await this.plugin.saveSettings();
 						}),
@@ -252,17 +249,16 @@ export class TimeThingsSettingsTab extends PluginSettingTab {
 		// #endregion
 
 
-		// #region keys
+		// #region Frontmatter
 		containerEl.createEl("h1", { text: "Frontmatter" });
 		containerEl.createEl("p", { text: "Handles timestamp keys in frontmatter." });
 
-		// #region frontmatter modification timestamp
+		// Modified timestamp
 		containerEl.createEl("h2", { text: "🔑 Modified timestamp" });
 		containerEl.createEl("p", { text: "Track the last time a note was edited." });
 		
-
 		new Setting(containerEl)
-			.setName("Enable update of the modified key") // TODO: only update after a certain amount has passed? Otherwise pretty useless depending on what triggers the tracking. I think mouse doesn't!
+			.setName("Enable update of the modified key")
 			.setDesc("")
 			.addToggle((toggle) =>
 				toggle
@@ -314,7 +310,7 @@ export class TimeThingsSettingsTab extends PluginSettingTab {
 			let thresholdText: TextComponent;
 			new Setting(containerEl.createDiv({cls: "textbox"}))
 				.setName("Date refresh threshold")
-				.setDesc("Active typing duration that must be exceeded in one continuous period for the modification date to be updated. Will always be updated if lower than the editing timeout.")
+				.setDesc("Active typing duration that must be exceeded in one continuous period for the modification date to be updated.")
 				.addSlider((slider) => slider // implicit return without curlies
 					.setLimits(0, 60, 1)
 					.setValue(this.plugin.settings.modifiedThreshold / 1000)
@@ -339,7 +335,7 @@ export class TimeThingsSettingsTab extends PluginSettingTab {
 		}
 		// #endregion
 
-		// #region edited_duration key
+		// Edit duration
 		containerEl.createEl("h2", { text: "🔑 Edited duration" });
 		containerEl.createEl("p", {
 			text: "Track for how long you have been editing a note.",
@@ -399,8 +395,7 @@ export class TimeThingsSettingsTab extends PluginSettingTab {
 		// #endregion
 
 
-		// #region danger zone
-
+		// #region Danger zone
 		containerEl.createEl("h1", { text: "Danger zone" });
 		containerEl.createEl("p", { text: "You've been warned!" });
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -116,7 +116,7 @@ export class TimeThingsSettingsTab extends PluginSettingTab {
 			);
 
 		new Setting(containerEl.createDiv({cls: "textbox"}))
-		.setName(`Editing Timeout for ${this.plugin.settings.useCustomFrontmatterHandlingSolution === false ? "BOMS" : "CAMS"}`)
+		.setName("Editing Timeout")
 		.setDesc(description)
 		.addSlider((slider) => mySlider = slider // implicit return without curlies
 		.setLimits(minTimeoutCams, 90, 1)
@@ -172,9 +172,17 @@ export class TimeThingsSettingsTab extends PluginSettingTab {
 					text
 						.setPlaceholder("hh:mm A")
 						.setValue(this.plugin.settings.clockFormat)
-						.onChange(async (value) => {
-							this.plugin.settings.clockFormat = value;
-							await this.plugin.saveSettings();
+						.onChange(async (formatter) => {
+							// Validate formatter by using it
+							const formatTest = moment().format(formatter);
+							const valid = moment(formatTest, formatter).isValid();
+							if(!valid) {
+								text.inputEl.addClass('invalid-format');
+							} else {
+								text.inputEl.removeClass('invalid-format');
+								this.plugin.settings.clockFormat = formatter;
+								await this.plugin.saveSettings();
+							}
 						}),
 				);
 
@@ -279,7 +287,7 @@ export class TimeThingsSettingsTab extends PluginSettingTab {
 						.setPlaceholder("YYYY-MM-DD[T]HH:mm:ss.SSSZ")
 						.setValue(this.plugin.settings.modifiedKeyFormat)
 						.onChange(async (formatter) => {
-							// Try formatting the current date
+							// Validate formatter by using it
 							const formatTest = moment().format(formatter);
 							const valid = moment(formatTest, formatter).isValid();
 							if(!valid) {
@@ -337,9 +345,17 @@ export class TimeThingsSettingsTab extends PluginSettingTab {
 					text
 						.setPlaceholder("HH:mm:ss.SSSZ")
 						.setValue(this.plugin.settings.editDurationKeyFormat)
-						.onChange(async (value) => {
-							this.plugin.settings.editDurationKeyFormat = value;
-							await this.plugin.saveSettings();
+						.onChange(async (formatter) => {
+							// Validate formatter by using it
+							const formatTest = moment().format(formatter);
+							const valid = moment(formatTest, formatter).isValid();
+							if(!valid) {
+								text.inputEl.addClass('invalid-format');
+							} else {
+								text.inputEl.removeClass('invalid-format');
+								this.plugin.settings.editDurationKeyFormat = formatter;
+								await this.plugin.saveSettings();
+							}
 						}),
 				);
 			}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -22,16 +22,14 @@ export interface TimeThingsSettings {
 	updateIntervalFrontmatterMinutes: number;
 
     //DURATION KEY
-	editDurationPath: string;
-	editDurationFormat: string;
+	editDurationKeyName: string;
+	editDurationKeyFormat: string;
 	enableEditDurationKey: boolean;
 	nonTypingEditingTimePercentage: number;
 
 	enableSwitch: boolean;
 	switchKey: string;
 	switchKeyValue: string;
-
-
     
 }
 
@@ -49,8 +47,8 @@ export const DEFAULT_SETTINGS: TimeThingsSettings = {
 	modifiedKeyFormat: "YYYY-MM-DD[T]HH:mm:ss.SSSZ",
 	enableModifiedKeyUpdate: true,
 
-	editDurationPath: "edited_seconds",
-	editDurationFormat: "HH:mm:ss",
+	editDurationKeyName: "edited_seconds",
+	editDurationKeyFormat: "HH:mm:ss",
 	enableEditDurationKey: true,
 
 	updateIntervalFrontmatterMinutes: 1,
@@ -306,9 +304,9 @@ export class TimeThingsSettingsTab extends PluginSettingTab {
 				.addText((text) =>
 					text
 						.setPlaceholder("edited_seconds")
-						.setValue(this.plugin.settings.editDurationPath)
+						.setValue(this.plugin.settings.editDurationKeyName)
 						.onChange(async (value) => {
-							this.plugin.settings.editDurationPath = value;
+							this.plugin.settings.editDurationKeyName = value;
 							await this.plugin.saveSettings();
 						}),
 				);
@@ -319,9 +317,9 @@ export class TimeThingsSettingsTab extends PluginSettingTab {
 				.addText((text) =>
 					text
 						.setPlaceholder("HH:mm:ss.SSSZ")
-						.setValue(this.plugin.settings.editDurationFormat)
+						.setValue(this.plugin.settings.editDurationKeyFormat)
 						.onChange(async (value) => {
-							this.plugin.settings.editDurationFormat = value;
+							this.plugin.settings.editDurationKeyFormat = value;
 							await this.plugin.saveSettings();
 						}),
 				);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -23,6 +23,7 @@ export interface TimeThingsSettings {
 
     //DURATION KEY
 	editDurationPath: string;
+	editDurationFormat: string;
 	enableEditDurationKey: boolean;
 	nonTypingEditingTimePercentage: number;
 
@@ -49,6 +50,7 @@ export const DEFAULT_SETTINGS: TimeThingsSettings = {
 	enableModifiedKeyUpdate: true,
 
 	editDurationPath: "edited_seconds",
+	editDurationFormat: "HH:mm:ss",
 	enableEditDurationKey: true,
 
 	updateIntervalFrontmatterMinutes: 1,
@@ -307,6 +309,19 @@ export class TimeThingsSettingsTab extends PluginSettingTab {
 						.setValue(this.plugin.settings.editDurationPath)
 						.onChange(async (value) => {
 							this.plugin.settings.editDurationPath = value;
+							await this.plugin.saveSettings();
+						}),
+				);
+
+			new Setting(containerEl)
+				.setName("Edited duration key format")
+				.setDesc(createLink())
+				.addText((text) =>
+					text
+						.setPlaceholder("HH:mm:ss.SSSZ")
+						.setValue(this.plugin.settings.editDurationFormat)
+						.onChange(async (value) => {
+							this.plugin.settings.editDurationFormat = value;
 							await this.plugin.saveSettings();
 						}),
 				);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -130,7 +130,6 @@ export class TimeThingsSettingsTab extends PluginSettingTab {
 			);
 
 		new Setting(containerEl.createDiv({cls: "textbox"}))
-		// .setName("Interval between updates")
 		.setName(`Editing Timeout for ${this.plugin.settings.useCustomFrontmatterHandlingSolution === false ? "BOMS" : "CAMS"}`)
 		.setDesc(description)
 		.addSlider((slider) => mySlider = slider // implicit return without curlies

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -2,67 +2,51 @@ import { App, PluginSettingTab, Setting, SliderComponent, TextComponent } from "
 import TimeThings from "./main";
 
 export interface TimeThingsSettings {
-    //CAMS
+    //CAMS/BOMS
 	useCustomFrontmatterHandlingSolution: boolean;
+	typingTimeoutMilliseconds: number;
 
     //CLOCK
 	clockFormat: string;
-	updateIntervalMilliseconds: string;
 	enableClock: boolean;
 	isUTC: boolean;
-
+	
     //MODIFIED KEY
 	enableModifiedKey: boolean;
 	modifiedKeyName: string;
 	modifiedKeyFormat: string;
-    //BOMS
-	updateIntervalFrontmatterMinutes: number;
-
+	
     //DURATION KEY
 	enableEditDurationKey: boolean;
 	editDurationKeyName: string;
 	editDurationKeyFormat: string;
-	nonTypingEditingTimePercentage: number;
-	editTimeoutMilliseconds: number;
+	
+	// EDIT INDICATOR
 	enableEditStatus: boolean;
 	editIndicatorActive: string;
 	editIndicatorInactive: string;
-
-	enableSwitch: boolean;
-	switchKey: string;
-	switchKeyValue: string;
-    
 }
 
 export const DEFAULT_SETTINGS: TimeThingsSettings = {
 	useCustomFrontmatterHandlingSolution: false,
+	typingTimeoutMilliseconds: 3000,
 
 	clockFormat: "hh:mm A",
-	updateIntervalMilliseconds: "1000",
 	enableClock: true,
 	isUTC: false,
-
+	
 	modifiedKeyName: "updated_at",
 	modifiedKeyFormat: "YYYY-MM-DD[T]HH:mm:ss.SSSZ",
 	enableModifiedKey: true,
-
+	
 	editDurationKeyName: "edited_seconds",
 	editDurationKeyFormat: "HH:mm:ss",
 	enableEditDurationKey: true,
-	editTimeoutMilliseconds: 3000,
+	
+	// EDIT INDICATOR
 	enableEditStatus: true,
 	editIndicatorActive: "✏🔵",
 	editIndicatorInactive: "✋🔴",
-
-	updateIntervalFrontmatterMinutes: 1,
-
-	nonTypingEditingTimePercentage: 22,
-
-	enableSwitch: false,
-	switchKey: "timethings.switch",
-	switchKeyValue: "true",
-
-
 };
 
 export class TimeThingsSettingsTab extends PluginSettingTab {
@@ -119,10 +103,10 @@ export class TimeThingsSettingsTab extends PluginSettingTab {
 							description += " Switch to default frontmatter solution for values <10s.";
 							console.log(mySlider.getValue());
 							mySlider.setLimits(minTimeoutBoms, 90, 1);
-							if(this.plugin.settings.editTimeoutMilliseconds < minTimeoutBoms * 1000) {
-								this.plugin.settings.editTimeoutMilliseconds = minTimeoutBoms * 1000;
+							if(this.plugin.settings.typingTimeoutMilliseconds < minTimeoutBoms * 1000) {
+								this.plugin.settings.typingTimeoutMilliseconds = minTimeoutBoms * 1000;
 								myText.setValue(minTimeoutBoms.toString());
-								console.log("Bump BOMS timeout", this.plugin.settings.editTimeoutMilliseconds);
+								console.log("Bump BOMS timeout", this.plugin.settings.typingTimeoutMilliseconds);
 							}
 						}
 						await this.plugin.saveSettings();
@@ -134,9 +118,9 @@ export class TimeThingsSettingsTab extends PluginSettingTab {
 		.setDesc(description)
 		.addSlider((slider) => mySlider = slider // implicit return without curlies
 		.setLimits(minTimeoutCams, 90, 1)
-		.setValue(this.plugin.settings.editTimeoutMilliseconds / 1000)
+		.setValue(this.plugin.settings.typingTimeoutMilliseconds / 1000)
 		.onChange(async (value) => {
-			this.plugin.settings.editTimeoutMilliseconds = value * 1000;
+			this.plugin.settings.typingTimeoutMilliseconds = value * 1000;
 			myText.setValue(value.toString());
 			await this.plugin.saveSettings();
 		})
@@ -145,10 +129,10 @@ export class TimeThingsSettingsTab extends PluginSettingTab {
 		.addText((text) => {
 				myText = text
 				.setPlaceholder("50")
-				.setValue((this.plugin.settings.editTimeoutMilliseconds/1000).toString(),)
+				.setValue((this.plugin.settings.typingTimeoutMilliseconds/1000).toString(),)
 				.onChange(async (value) => {
 					const numericValue = parseInt(value, 10);
-					this.plugin.settings.editTimeoutMilliseconds = numericValue * 1000;
+					this.plugin.settings.typingTimeoutMilliseconds = numericValue * 1000;
 					mySlider.setValue(numericValue);
 					await this.plugin.saveSettings();
 				})

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -103,7 +103,7 @@ export class TimeThingsSettingsTab extends PluginSettingTab {
 						else {
 							// BOMS: Raise lower limit and bump if below
 							description += " Switch to default frontmatter solution for values <10s.";
-							console.log(mySlider.getValue());
+							// console.log("Slider lower limit: ", mySlider.getValue());
 							mySlider.setLimits(minTimeoutBoms, 90, 1);
 							if(this.plugin.settings.typingTimeoutMilliseconds < minTimeoutBoms * 1000) {
 								this.plugin.settings.typingTimeoutMilliseconds = minTimeoutBoms * 1000;
@@ -119,7 +119,7 @@ export class TimeThingsSettingsTab extends PluginSettingTab {
 		.setName("Editing Timeout")
 		.setDesc(description)
 		.addSlider((slider) => mySlider = slider // implicit return without curlies
-		.setLimits(minTimeoutCams, 90, 1)
+		.setLimits(minTimeoutBoms, 90, 1)
 		.setValue(this.plugin.settings.typingTimeoutMilliseconds / 1000)
 		.onChange(async (value) => {
 			this.plugin.settings.typingTimeoutMilliseconds = value * 1000;
@@ -160,6 +160,7 @@ export class TimeThingsSettingsTab extends PluginSettingTab {
 					.onChange(async (newValue) => {
 						this.plugin.settings.enableClock = newValue;
 						await this.plugin.saveSettings();
+						await this.plugin.loadSettings();
 						await this.display();
 					}),
 			);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,4 +1,4 @@
-import { App, PluginSettingTab, Setting } from "obsidian";
+import { App, PluginSettingTab, Setting, SliderComponent, TextComponent } from "obsidian";
 import TimeThings from "./main";
 
 export interface TimeThingsSettings {
@@ -250,28 +250,42 @@ export class TimeThingsSettingsTab extends PluginSettingTab {
 						}),
 				);
 
-			if (
-				this.plugin.settings.useCustomFrontmatterHandlingSolution ===
-				false
-			) {
+			
+				let mySlider : SliderComponent;
+				let myText: TextComponent;
+				let minValue = 1
+				if (this.plugin.settings.useCustomFrontmatterHandlingSolution === false) {
+					minValue = 10;
+				}	
 				new Setting(containerEl)
-					.setName("Interval between updates")
-					.setDesc("Only for Obsidian frontmatter API.")
+					// .setName("Interval between updates")
+					.setName(`Editing Timeout for ${this.plugin.settings.useCustomFrontmatterHandlingSolution === false ? "BOMS" : "CAMS"}`)
+					.setDesc("Timeout in seconds to stop counting. Also reflected in the status bar. Affects all update frequencies. IF DEFAULT IS ACTIVE THEN > 10, OTHERWISE >1!!! ENFORECE! Also preview on slider wrong.")
 					.addSlider((slider) =>
-						slider
-							.setLimits(1, 15, 1)
+						mySlider = slider
+							.setLimits(1, 90, 1)
 							.setValue(
-								this.plugin.settings
-									.updateIntervalFrontmatterMinutes,
+								this.plugin.settings.editTimeoutMilliseconds,
 							)
 							.onChange(async (value) => {
-								this.plugin.settings.updateIntervalFrontmatterMinutes =
-									value;
+								this.plugin.settings.editTimeoutMilliseconds = value * 1000;
+								myText.setValue(value.toString());
 								await this.plugin.saveSettings();
 							})
 							.setDynamicTooltip(),
-					);
-			}
+					)
+					.addText((text) =>
+						myText = text
+							.setPlaceholder("10020")
+							.setValue(
+								this.plugin.settings.editTimeoutMilliseconds.toString(),
+							)
+							.onChange(async (value) => {
+								const numericValue = parseInt(value, 10);
+								this.plugin.settings.editTimeoutMilliseconds = numericValue * 1000;
+								mySlider.setValue(numericValue);
+								await this.plugin.saveSettings();
+							}))
 		}
 
 		// #endregion

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -26,6 +26,7 @@ export interface TimeThingsSettings {
 	editDurationKeyFormat: string;
 	enableEditDurationKey: boolean;
 	nonTypingEditingTimePercentage: number;
+	editTimeoutMilliseconds: number;
 
 	enableSwitch: boolean;
 	switchKey: string;
@@ -50,6 +51,7 @@ export const DEFAULT_SETTINGS: TimeThingsSettings = {
 	editDurationKeyName: "edited_seconds",
 	editDurationKeyFormat: "HH:mm:ss",
 	enableEditDurationKey: true,
+	editTimeoutMilliseconds: 3000,
 
 	updateIntervalFrontmatterMinutes: 1,
 

--- a/styles.css
+++ b/styles.css
@@ -25,3 +25,17 @@ If your plugin does not need CSS, delete this file.
     max-height: 1rem;
     text-align: end;
 }
+
+.statusBarTypingIndicator input[type="text"]
+{
+    display: flex;
+    justify-content: flex-end;
+    text-align: center;
+    width: 5rem;
+}
+
+.textbox input[type="text"] 
+{
+    text-align: center;
+    width: 3rem;
+}

--- a/styles.css
+++ b/styles.css
@@ -39,3 +39,8 @@ If your plugin does not need CSS, delete this file.
     text-align: center;
     width: 3rem;
 }
+
+.setting-item .setting-item-control .invalid-format {
+    border-color: orangered;
+}
+


### PR DESCRIPTION
Hiho @plasmabit 

Great plugin! I've used it for a while and meant to add a formatter to the editing_time as #25 suggests. However, things escalated and I've... I've kinda re-written the core logic using debouncing.
It works the same, but improves on robustness and efficiency, especially avoiding excessive function calls.

Since I'm not completely done I'll open this as a draft, though I'm already using it for 1-2 weeks now. Let me know what you think in the meanwhile!

# Adds:
## Status Indicator
Emojis at the bottom indicating whether time is counted. 
![image](https://github.com/user-attachments/assets/7a0689d7-2d43-4778-b7a6-19331c8bccf1)
After typing is halted a configurable timeout counts down and resets the indicator. 
![image](https://github.com/user-attachments/assets/28f5b501-8324-4c80-8eb5-2ab8af6cb85a)
The frontmatter is not just updated after typing has stopped, but every x seconds (where x is the typing timeout). So if my typing timeout is set to 30 seconds and I type for 80 seconds the frontmatter is updated at 30s, 60s and then once more as the timer runs out.

## Modified timestamp
The modified time is now updated only if a configurable threshold is used. So if set to 30 seconds, the overall typing time needs to exceed 30 seconds. **Important**: When typing timeout >= modified threshold, the modified time will always be updated. I.e. when the typing icon is blue for longer than the modified threshold it updates.

# Restructures settings:
![image](https://github.com/user-attachments/assets/419bc8b2-e119-4471-8a83-5245443931f9)
![image](https://github.com/user-attachments/assets/28974fa4-881f-4352-a5ac-c96f1595016f)
- Date/Time formatter in settings are dynamically highlighted depending on validity
![image](https://github.com/user-attachments/assets/f414ac44-55e5-47db-adad-7ac9b899d067)


# Fixes:
- CAMS did not create frontmatter on empty notes
- CAMS did not create frontmatter entries after changing key names, it only modified existing ones
- #25 

# Current plan:
- Fix bug: When CAMS is selected in the settings the slider lower constraint should stay at 1 second but resets to the BOMS value of 10s when restarting the application. Only a graphical issue.
- Add global filter https://publish.obsidian.md/tasks/Getting+Started/Global+Filter #19 
- Update readme
- Unit-tests